### PR TITLE
Remove composite classes and implement comparators as hybrid properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ Or from GitHub:
 ## Usage
 
 ```python
-from healpix_alchemy.unit_spherical import (UnitSphericalCoordinate,
-                                            HasUnitSphericalCoordinate)
+from healpix_alchemy.unit_spherical import HasUnitSphericalCoordinate
 from sqlalchemy.ext.declarative import declarative_base
 
 Base = declarative_base()
@@ -45,9 +44,9 @@ class Point2(HasUnitSphericalCoordinate, Base):
 ...
 
 # Populate Point1 and Point2 tables with some sample data...
-session.add(Point1(id=0, coordinate=UnitSphericalCoordinate(lon=320.5, lat=-23.5)))
+session.add(Point1(id=0, lon=320.5, lat=-23.5))
 ...
-session.add(Point2(id=0, coordinate=UnitSphericalCoordinate(lon=18.1, lat=18.3)))
+session.add(Point2(id=0, lon=18.1, lat=18.3))
 ...
 session.commit()
 
@@ -58,7 +57,7 @@ query = session.query(
     Point1.id, Point2.id
 ).join(
     Point2,
-    Point1.coordinate.within(Point2.coordinate, separation)
+    Point1.within(Point2, separation)
 ).order_by(
     Point1.id, Point2.id
 )

--- a/healpix_alchemy/tests/test_unit_spherical.py
+++ b/healpix_alchemy/tests/test_unit_spherical.py
@@ -9,8 +9,8 @@ from sqlalchemy import Column, Integer
 from sqlalchemy.orm import aliased, sessionmaker
 import pytest
 
-from ..unit_spherical import (HasUnitSphericalCoordinate,
-                              UnitSphericalCoordinate)
+from ..unit_spherical import HasUnitSphericalCoordinate
+
 
 
 Base = declarative_base()
@@ -68,7 +68,7 @@ def point_clouds(request, session):
     # Commit to database
     for model_cls, lons_, lats_ in zip([Point1, Point2], lons, lats):
         for i, (lon, lat) in enumerate(zip(lons_, lats_)):
-            row = model_cls(id=i, coordinate=UnitSphericalCoordinate(lon, lat))
+            row = model_cls(id=i, lon=lon, lat=lat)
             session.add(row)
     session.commit()
 
@@ -85,7 +85,7 @@ def test_cross_join(benchmark, session, point_clouds):
             Point1.id, Point2.id
         ).join(
             Point2,
-            Point1.coordinate.within(Point2.coordinate, separation)
+            Point1.within(Point2, separation)
         ).order_by(
             Point1.id, Point2.id
         ).all()
@@ -109,7 +109,7 @@ def test_self_join(benchmark, session, point_clouds):
             table1.id, table2.id
         ).join(
             table2,
-            table1.coordinate.within(table2.coordinate, 1)
+            table1.within(table2, 1)
         ).order_by(
             table1.id, table2.id
         ).all()
@@ -124,7 +124,7 @@ def test_cone_search(benchmark, session, point_clouds):
             table1.id, table2.id
         ).join(
             table2,
-            table1.coordinate.within(table2.coordinate, 1)
+            table1.within(table2, 1)
         ).filter(
             table1.id == 0
         ).order_by(

--- a/healpix_alchemy/tests/test_unit_spherical.py
+++ b/healpix_alchemy/tests/test_unit_spherical.py
@@ -117,17 +117,13 @@ def test_self_join(benchmark, session, point_clouds):
 
 
 def test_cone_search(benchmark, session, point_clouds):
+    target = session.query(Point1).get(0)
     def do_query():
-        table1 = aliased(Point1)
-        table2 = aliased(Point2)
         return session.query(
-            table1.id, table2.id
-        ).join(
-            table2,
-            table1.within(table2, 1)
+            Point1.id
         ).filter(
-            table1.id == 0
+            Point1.within(target, 1)
         ).order_by(
-            table2.id
+            Point1.id
         ).all()
     benchmark(do_query)

--- a/healpix_alchemy/unit_spherical.py
+++ b/healpix_alchemy/unit_spherical.py
@@ -1,43 +1,18 @@
 from dataclasses import astuple, dataclass
 
 from sqlalchemy.ext.declarative import declared_attr
-from sqlalchemy.orm.properties import CompositeProperty
-from sqlalchemy.orm import composite
 from sqlalchemy.schema import Column, Index
 from sqlalchemy.sql import and_
 from sqlalchemy.types import Float
+from sqlalchemy.ext.hybrid import hybrid_method
 
 from .math import sind, cosd
 
-__all__ = ('UnitSphericalCoordinate', 'HasUnitSphericalCoordinate')
-
-
-@dataclass
-class UnitSphericalCoordinate:
-
-    lon: float  # longitude in degrees
-    lat: float  # latitude in degrees
-
-    def __composite_values__(self):
-        return astuple(self)
+__all__ = ('HasUnitSphericalCoordinate',)
 
 
 def _to_cartesian(lon, lat):
     return cosd(lon) * cosd(lat), sind(lon) * cosd(lat), sind(lat)
-
-
-class UnitSphericalCoordinateComparator(CompositeProperty.Comparator):
-
-    def cartesian(self):
-        return _to_cartesian(*self.__clause_element__().clauses)
-
-    def within(self, other, radius):
-        sin_radius = sind(radius)
-        cos_radius = cosd(radius)
-        carts = list(zip(*(obj.cartesian() for obj in (self, other))))
-        return and_(*(lhs.between(rhs - 2 * sin_radius, rhs + 2 * sin_radius)
-                      for lhs, rhs in carts),
-                    sum(lhs * rhs for lhs, rhs in carts) >= cos_radius)
 
 
 class HasUnitSphericalCoordinate:
@@ -45,10 +20,18 @@ class HasUnitSphericalCoordinate:
     lon = Column(Float, nullable=False)
     lat = Column(Float, nullable=False)
 
-    @declared_attr
-    def coordinate(cls):
-        return composite(UnitSphericalCoordinate, cls.lon, cls.lat,
-                         comparator_factory=UnitSphericalCoordinateComparator)
+    @hybrid_method
+    def cartesian(self):
+        return _to_cartesian(self.lon, self.lat)
+
+    @hybrid_method
+    def within(self, other, radius):
+        sin_radius = sind(radius)
+        cos_radius = cosd(radius)
+        carts = list(zip(*(obj.cartesian() for obj in (self, other))))
+        return and_(*(lhs.between(rhs - 2 * sin_radius, rhs + 2 * sin_radius)
+                      for lhs, rhs in carts),
+                    sum(lhs * rhs for lhs, rhs in carts) >= cos_radius)
 
     @declared_attr
     def __table_args__(cls):


### PR DESCRIPTION
This PR alters the implementation of `HasUnitSphericalCoordinate` to fix #1. 

- The `coordinate` attribute of `HasUnitSphericalCoordinate` has been removed in favor of direct access to the `lat` and `lon` columns. 
- The `UnitSphericalCoordinate` and `UnitSphericalCoordinateComparator` classes have been removed. 
- The `within` and `cartesian` functions of `UnitSphericalCoordinateComparator` have been absorbed into `HasUnitSphericalCoordinate`
- `within` and `cartesian` have been recast as `hybrid_method`s that operate directly on `lon` and `lat`, rather than `CompositeProperties`. 

The reimplementation of `within` and `cartesian` as `hybrid_method`s fixes the issue raised in #1 with no loss in performance. 