### PR TITLE
Allow users to decide what to call indexed columns 

### DIFF
--- a/healpix_alchemy/tests/test_unit_spherical.py
+++ b/healpix_alchemy/tests/test_unit_spherical.py
@@ -9,8 +9,8 @@ from sqlalchemy import Column, Integer
 from sqlalchemy.orm import aliased, sessionmaker
 import pytest
 
-from ..unit_spherical import (HasUnitSphericalCoordinate,
-                              UnitSphericalCoordinate)
+from ..unit_spherical import HasUnitSphericalCoordinate
+
 
 
 Base = declarative_base()
@@ -68,7 +68,7 @@ def point_clouds(request, session):
     # Commit to database
     for model_cls, lons_, lats_ in zip([Point1, Point2], lons, lats):
         for i, (lon, lat) in enumerate(zip(lons_, lats_)):
-            row = model_cls(id=i, coordinate=UnitSphericalCoordinate(lon, lat))
+            row = model_cls(id=i, lon=lon, lat=lat)
             session.add(row)
     session.commit()
 
@@ -85,7 +85,7 @@ def test_cross_join(benchmark, session, point_clouds):
             Point1.id, Point2.id
         ).join(
             Point2,
-            Point1.coordinate.within(Point2.coordinate, separation)
+            Point1.within(Point2, separation)
         ).order_by(
             Point1.id, Point2.id
         ).all()
@@ -109,7 +109,7 @@ def test_self_join(benchmark, session, point_clouds):
             table1.id, table2.id
         ).join(
             table2,
-            table1.coordinate.within(table2.coordinate, 1)
+            table1.within(table2, 1)
         ).order_by(
             table1.id, table2.id
         ).all()
@@ -124,7 +124,7 @@ def test_cone_search(benchmark, session, point_clouds):
             table1.id, table2.id
         ).join(
             table2,
-            table1.coordinate.within(table2.coordinate, 1)
+            table1.within(table2, 1)
         ).filter(
             table1.id == 0
         ).order_by(

--- a/healpix_alchemy/tests/test_unit_spherical.py
+++ b/healpix_alchemy/tests/test_unit_spherical.py
@@ -117,17 +117,13 @@ def test_self_join(benchmark, session, point_clouds):
 
 
 def test_cone_search(benchmark, session, point_clouds):
+    target = session.query(Point1).get(0)
     def do_query():
-        table1 = aliased(Point1)
-        table2 = aliased(Point2)
         return session.query(
-            table1.id, table2.id
-        ).join(
-            table2,
-            table1.within(table2, 1)
+            Point1.id
         ).filter(
-            table1.id == 0
+            Point1.within(target, 1)
         ).order_by(
-            table2.id
+            Point1.id
         ).all()
     benchmark(do_query)

--- a/healpix_alchemy/unit_spherical.py
+++ b/healpix_alchemy/unit_spherical.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.hybrid import hybrid_method
 
 from .math import sind, cosd
 
-__all__ = ('HasUnitSphericalCoordinate',)
+__all__ = ('HasUnitSphericalCoordinate', 'HasRADec')
 
 
 def _to_cartesian(lon, lat):

--- a/healpix_alchemy/unit_spherical.py
+++ b/healpix_alchemy/unit_spherical.py
@@ -15,30 +15,51 @@ def _to_cartesian(lon, lat):
     return cosd(lon) * cosd(lat), sind(lon) * cosd(lat), sind(lat)
 
 
-class HasUnitSphericalCoordinate:
+def class_factory(lon_name='lon', lat_name='lat', nullable=False):
 
-    lon = Column(Float, nullable=False)
-    lat = Column(Float, nullable=False)
+    class _SphericalCoordinateBase(object):
 
-    @hybrid_method
-    def cartesian(self):
-        return _to_cartesian(self.lon, self.lat)
+        @hybrid_method
+        def within(self, other, radius):
+            sin_radius = sind(radius)
+            cos_radius = cosd(radius)
+            carts = list(zip(*(obj.cartesian() for obj in (self, other))))
+            return and_(
+                *(lhs.between(rhs - 2 * sin_radius, rhs + 2 * sin_radius)
+                  for lhs, rhs in carts),
+                sum(lhs * rhs for lhs, rhs in carts) >= cos_radius)
 
-    @hybrid_method
-    def within(self, other, radius):
-        sin_radius = sind(radius)
-        cos_radius = cosd(radius)
-        carts = list(zip(*(obj.cartesian() for obj in (self, other))))
-        return and_(*(lhs.between(rhs - 2 * sin_radius, rhs + 2 * sin_radius)
-                      for lhs, rhs in carts),
-                    sum(lhs * rhs for lhs, rhs in carts) >= cos_radius)
+        @hybrid_method
+        def cartesian(self):
+            lon = getattr(self, self.lon_name)
+            lat = getattr(self, self.lat_name)
+            return _to_cartesian(lon, lat)
 
-    @declared_attr
-    def __table_args__(cls):
-        try:
-            args = super().__table_args__
-        except AttributeError:
-            args = ()
-        args += tuple(Index(f'{cls.__tablename__}_{k}_index', v)
-                      for k, v in zip('xyz', _to_cartesian(cls.lon, cls.lat)))
-        return args
+        @declared_attr
+        def __table_args__(cls):
+
+            lon = getattr(cls, cls.lon_name)
+            lat = getattr(cls, cls.lat_name)
+
+            try:
+                args = super().__table_args__
+            except AttributeError:
+                args = ()
+            args += tuple(Index(f'{cls.__tablename__}_{k}_index', v)
+                          for k, v in zip('xyz', _to_cartesian(lon, lat)))
+            return args
+
+    lon = Column(lon_name, Float, nullable=nullable)
+    lat = Column(lat_name, Float, nullable=nullable)
+
+    setattr(_SphericalCoordinateBase, lon_name, lon)
+    setattr(_SphericalCoordinateBase, lat_name, lat)
+
+    _SphericalCoordinateBase.lon_name = lon_name
+    _SphericalCoordinateBase.lat_name = lat_name
+
+    return _SphericalCoordinateBase
+
+
+HasUnitSphericalCoordinate = class_factory()
+HasRADec = class_factory('ra', 'dec')

--- a/healpix_alchemy/unit_spherical.py
+++ b/healpix_alchemy/unit_spherical.py
@@ -1,43 +1,18 @@
 from dataclasses import astuple, dataclass
 
 from sqlalchemy.ext.declarative import declared_attr
-from sqlalchemy.orm.properties import CompositeProperty
-from sqlalchemy.orm import composite
 from sqlalchemy.schema import Column, Index
 from sqlalchemy.sql import and_
 from sqlalchemy.types import Float
+from sqlalchemy.ext.hybrid import hybrid_method
 
 from .math import sind, cosd
 
-__all__ = ('UnitSphericalCoordinate', 'HasUnitSphericalCoordinate')
-
-
-@dataclass
-class UnitSphericalCoordinate:
-
-    lon: float  # longitude in degrees
-    lat: float  # latitude in degrees
-
-    def __composite_values__(self):
-        return astuple(self)
+__all__ = ('HasUnitSphericalCoordinate',)
 
 
 def _to_cartesian(lon, lat):
     return cosd(lon) * cosd(lat), sind(lon) * cosd(lat), sind(lat)
-
-
-class UnitSphericalCoordinateComparator(CompositeProperty.Comparator):
-
-    def cartesian(self):
-        return _to_cartesian(*self.__clause_element__().clauses)
-
-    def within(self, other, radius):
-        sin_radius = sind(radius)
-        cos_radius = cosd(radius)
-        carts = list(zip(*(obj.cartesian() for obj in (self, other))))
-        return and_(*(lhs.between(rhs - 2 * sin_radius, rhs + 2 * sin_radius)
-                      for lhs, rhs in carts),
-                    sum(lhs * rhs for lhs, rhs in carts) >= cos_radius)
 
 
 class HasUnitSphericalCoordinate:
@@ -45,10 +20,18 @@ class HasUnitSphericalCoordinate:
     lon = Column(Float, nullable=False)
     lat = Column(Float, nullable=False)
 
-    @declared_attr
-    def coordinate(cls):
-        return composite(UnitSphericalCoordinate, cls.lon, cls.lat,
-                         comparator_factory=UnitSphericalCoordinateComparator)
+    @hybrid_method
+    def cartesian(self):
+        return _to_cartesian(self.lon, self.lat)
+
+    @hybrid_method
+    def within(self, other, radius):
+        sin_radius = sind(radius)
+        cos_radius = cosd(radius)
+        carts = list(zip(*(obj.cartesian() for obj in (self, other))))
+        return and_(*(lhs.between(rhs - 2 * sin_radius, rhs + 2 * sin_radius)
+                      for lhs, rhs in carts),
+                    sum(lhs * rhs for lhs, rhs in carts) >= cos_radius)
 
     @declared_attr
     def __table_args__(cls):


### PR DESCRIPTION
This PR extends #2 by using a class factory pattern to grant users the freedom to choose what to call the `lon`, `lat` columns on a table that mixes the unitsphere mixin, while ensuring that the corresponding sqlalchemy attributes are named accordingly. This fixes the issue causing test failures on skyportal/skyportal#554, where the application was prevented from starting due to the API expecting fields named "ra" and "dec" on spatially indexed tables.

This PR contains 2 commits in common with #2 and should only be merged or rejected after a decision is reached on that PR. 