### PR TITLE
Allow RA and Dec to be nullable

### DIFF
--- a/healpix_alchemy/point.py
+++ b/healpix_alchemy/point.py
@@ -7,7 +7,7 @@ from sqlalchemy.types import Float
 
 from .math import sind, cosd
 
-__all__ = ('Point', 'HasPoint', 'HasPointNullable')
+__all__ = ('Point', 'HasPoint', 'HasNullablePoint')
 
 
 class Point(Comparator):
@@ -84,4 +84,4 @@ def point_factory(nullable=False):
     return _HasPoint
 
 HasPoint = point_factory()
-HasPointNullable = point_factory(nullable=True)
+HasNullablePoint = point_factory(nullable=True)

--- a/healpix_alchemy/point.py
+++ b/healpix_alchemy/point.py
@@ -57,8 +57,8 @@ class Point(Comparator):
 class HasPoint:
     """Mixin class to add a point to a an SQLAlchemy declarative model."""
 
-    ra = Column(Float, nullable=False)
-    dec = Column(Float, nullable=False)
+    ra = Column(Float, nullable=True)
+    dec = Column(Float, nullable=True)
 
     @hybrid_property
     def point(self):


### PR DESCRIPTION
This PR removes the nonnull constraint from RA and Dec, accommodating models in Skyportal such as `Photometry` which sometimes have coordinate information supplied and other times not 