### PR TITLE
Combine Cartesian components into one multicolumn index

### DIFF
--- a/healpix_alchemy/point.py
+++ b/healpix_alchemy/point.py
@@ -77,8 +77,8 @@ def point_factory(nullable=False):
                 args = super().__table_args__
             except AttributeError:
                 args = ()
-            args += tuple(Index(f'ix_{cls.__tablename__}_{k}', v)
-                          for k, v in zip('xyz', cls.point.cartesian))
+            index_name = f'ix_{cls.__tablename__}_point'
+            args += (Index(index_name, *cls.point.cartesian),)
             return args
 
     return _HasPoint


### PR DESCRIPTION
This is significantly faster than using three separate single column indices.

## Benchmark comparison

```
------------------------------------------------------------------------------------------------- benchmark: 32 tests --------------------------------------------------------------------------------------------------
Name (time in ms)                                      Min                 Max                Mean             StdDev              Median                IQR            Outliers       OPS            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_cone_search[10000] (0001_master)               1.5991 (1.08)       3.1132 (1.29)       1.9039 (1.14)      0.2374 (1.53)       1.8553 (1.12)      0.1792 (1.48)        84;36  525.2373 (0.88)        418           1
test_cone_search[10000] (NOW)                       1.5651 (1.05)       3.4499 (1.43)       1.7522 (1.05)      0.2321 (1.50)       1.7064 (1.03)      0.1638 (1.36)        28;26  570.7260 (0.96)        412           1
test_cone_search[1000] (0001_master)                1.5316 (1.03)       3.0875 (1.28)       1.7478 (1.04)      0.2158 (1.40)       1.7058 (1.03)      0.1597 (1.32)        33;29  572.1336 (0.96)        408           1
test_cone_search[1000] (NOW)                        1.5337 (1.03)       2.5332 (1.05)       1.7191 (1.03)      0.1828 (1.18)       1.6813 (1.02)      0.1606 (1.33)        46;37  581.7164 (0.97)        448           1
test_cone_search[100] (0001_master)                 1.5403 (1.04)       3.8839 (1.61)       1.7583 (1.05)      0.2509 (1.62)       1.7020 (1.03)      0.1741 (1.44)        35;31  568.7205 (0.95)        429           1
test_cone_search[100] (NOW)                         1.5172 (1.02)      52.6781 (21.78)      1.8205 (1.09)      2.4102 (15.58)      1.6793 (1.02)      0.1350 (1.12)         1;40  549.2918 (0.92)        450           1
test_cone_search[10] (0001_master)                  1.5302 (1.03)       4.3361 (1.79)       1.8629 (1.11)      0.3193 (2.06)       1.7627 (1.07)      0.2481 (2.05)        56;37  536.7877 (0.90)        439           1
test_cone_search[10] (NOW)                          1.5418 (1.04)      50.1805 (20.75)      1.8094 (1.08)      2.3239 (15.02)      1.6751 (1.01)      0.1208 (1.0)          2;34  552.6550 (0.93)        439           1
test_cone_search_literal[10000] (0001_master)       1.6037 (1.08)       3.0579 (1.26)       1.9120 (1.14)      0.2510 (1.62)       1.8385 (1.11)      0.2115 (1.75)        77;34  523.0219 (0.88)        340           1
test_cone_search_literal[10000] (NOW)               1.5577 (1.05)       2.4183 (1.0)        1.6830 (1.00)      0.1547 (1.0)        1.6744 (1.01)      0.1233 (1.02)        27;22  594.1793 (1.00)        370           1
test_cone_search_literal[1000] (0001_master)        1.5406 (1.04)      43.1985 (17.86)      1.8318 (1.09)      2.2157 (14.32)      1.6880 (1.02)      0.1392 (1.15)         1;24  545.9077 (0.91)        353           1
test_cone_search_literal[1000] (NOW)                1.5115 (1.02)       4.0337 (1.67)       1.7060 (1.02)      0.2373 (1.53)       1.6691 (1.01)      0.1239 (1.03)        31;32  586.1641 (0.98)        360           1
test_cone_search_literal[100] (0001_master)         1.5203 (1.02)       3.5806 (1.48)       1.7156 (1.02)      0.2131 (1.38)       1.6745 (1.01)      0.1566 (1.30)        33;29  582.8949 (0.98)        396           1
test_cone_search_literal[100] (NOW)                 1.5167 (1.02)       3.0028 (1.24)       1.7256 (1.03)      0.1972 (1.27)       1.6784 (1.02)      0.1817 (1.50)        40;23  579.5121 (0.97)        355           1
test_cone_search_literal[10] (0001_master)          1.5263 (1.03)       3.3138 (1.37)       1.8243 (1.09)      0.2757 (1.78)       1.7264 (1.04)      0.2607 (2.16)        62;26  548.1485 (0.92)        405           1
test_cone_search_literal[10] (NOW)                  1.4862 (1.0)        3.2998 (1.36)       1.6750 (1.0)       0.1934 (1.25)       1.6534 (1.0)       0.1236 (1.02)        30;30  597.0068 (1.0)         415           1
test_cross_join[10000] (0001_master)              542.6455 (365.11)   590.7575 (244.29)   557.1839 (332.64)   19.9393 (128.87)   549.9101 (332.60)   24.1067 (199.58)        1;0    1.7947 (0.00)          5           1
test_cross_join[10000] (NOW)                      162.8226 (109.55)   207.3451 (85.74)    172.2326 (102.82)   17.2704 (111.62)   165.5481 (100.13)    2.7022 (22.37)         1;1    5.8061 (0.01)          6           1
test_cross_join[1000] (0001_master)                10.8585 (7.31)      14.3130 (5.92)      12.0118 (7.17)      0.6395 (4.13)      11.9404 (7.22)      0.9643 (7.98)         27;1   83.2517 (0.14)         80           1
test_cross_join[1000] (NOW)                         4.0398 (2.72)       5.7732 (2.39)       4.4603 (2.66)      0.3025 (1.95)       4.3862 (2.65)      0.2809 (2.33)        33;13  224.2026 (0.38)        149           1
test_cross_join[100] (0001_master)                  1.8057 (1.21)       4.2493 (1.76)       2.2261 (1.33)      0.2874 (1.86)       2.1591 (1.31)      0.2394 (1.98)        59;22  449.2137 (0.75)        272           1
test_cross_join[100] (NOW)                          1.6804 (1.13)      49.7899 (20.59)      2.0183 (1.20)      2.6311 (17.01)      1.8355 (1.11)      0.1408 (1.17)         1;32  495.4625 (0.83)        334           1
test_cross_join[10] (0001_master)                   1.6494 (1.11)       2.9843 (1.23)       1.8238 (1.09)      0.2162 (1.40)       1.7867 (1.08)      0.1537 (1.27)        32;29  548.3098 (0.92)        371           1
test_cross_join[10] (NOW)                           1.6069 (1.08)       2.6656 (1.10)       1.7694 (1.06)      0.1798 (1.16)       1.7445 (1.06)      0.1322 (1.09)        26;24  565.1592 (0.95)        281           1
test_self_join[10000] (0001_master)               539.7892 (363.19)   595.6854 (246.33)   560.5436 (334.65)   24.5574 (158.72)   551.1191 (333.33)   40.9207 (338.79)        1;0    1.7840 (0.00)          5           1
test_self_join[10000] (NOW)                       184.7883 (124.33)   231.8974 (95.89)    200.8725 (119.92)   22.9253 (148.17)   187.2115 (113.23)   43.7224 (361.98)        2;0    4.9783 (0.01)          6           1
test_self_join[1000] (0001_master)                 13.6518 (9.19)      61.4116 (25.40)     15.2436 (9.10)      5.9472 (38.44)     14.4786 (8.76)      0.6328 (5.24)          1;2   65.6012 (0.11)         63           1
test_self_join[1000] (NOW)                          6.3320 (4.26)      59.1504 (24.46)      7.4969 (4.48)      4.7291 (30.56)      6.9317 (4.19)      0.6009 (4.97)          1;8  133.3891 (0.22)        123           1
test_self_join[100] (0001_master)                   2.6420 (1.78)       4.9386 (2.04)       3.0320 (1.81)      0.3445 (2.23)       2.9085 (1.76)      0.3698 (3.06)        39;10  329.8108 (0.55)        221           1
test_self_join[100] (NOW)                           2.2944 (1.54)       4.5985 (1.90)       2.6388 (1.58)      0.3616 (2.34)       2.5362 (1.53)      0.1665 (1.38)        28;33  378.9660 (0.63)        264           1
test_self_join[10] (0001_master)                    2.1461 (1.44)      50.7654 (20.99)      2.6572 (1.59)      2.9046 (18.77)      2.3767 (1.44)      0.2614 (2.16)         1;22  376.3349 (0.63)        279           1
test_self_join[10] (NOW)                            2.0467 (1.38)       4.1353 (1.71)       2.3514 (1.40)      0.2531 (1.64)       2.2921 (1.39)      0.1494 (1.24)        28;23  425.2864 (0.71)        287           1
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```