### PR TITLE
Unify Point and HasPoint into a single Point class

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You can install `healpix_alchemy` the Python Package Index:
 ## Usage
 
 ```python
-from healpix_alchemy.point import HasPoint, Point
+from healpix_alchemy.point import Point
 from sqlalchemy.ext.declarative import declarative_base
 
 Base = declarative_base()
@@ -27,12 +27,12 @@ Base = declarative_base()
 
 # Create two tables Catalog1 and Catalog2 that both have spherical coordinates.
 
-class Catalog1(HasPoint, Base):
+class Catalog1(Point, Base):
     __tablename__ = 'catalog1'
     id = Column(Integer, primary_key=True)
 
 
-class Catalog2(HasPoint, Base):
+class Catalog2(Point, Base):
     __tablename__ = 'catalog2'
     id = Column(Integer, primary_key=True)
 
@@ -40,9 +40,9 @@ class Catalog2(HasPoint, Base):
 ...
 
 # Populate Catalog1 and Catalog2 tables with some sample data...
-session.add(Catalog1(id=0, point=Point(ra=320.5, dec=-23.5)))
+session.add(Catalog1(id=0, ra=320.5, dec=-23.5))
 ...
-session.add(Catalog2(id=0, point=Point(ra=18.1, dec=18.3)))
+session.add(Catalog2(id=0, ra=18.1, dec=18.3))
 ...
 session.commit()
 
@@ -53,9 +53,23 @@ query = session.query(
     Catalog1.id, Catalog2.id
 ).join(
     Catalog2,
-    Catalog1.point.within(Catalog2.point, separation)
+    Catalog1.within(point, separation)
 ).order_by(
     Catalog1.id, Catalog2.id
+)
+for row in query:
+    ...  # do something with the query results
+
+
+# Do a cone search around literal ra, dec values.
+separation = 1  # separation in degrees
+point = Point(ra=212.5, dec=-33.2)
+query = session.query(
+    Catalog1.id
+).filter(
+    Catalog1.within(point, separation)
+).order_by(
+    Catalog1.id
 )
 for row in query:
     ...  # do something with the query results

--- a/healpix_alchemy/__init__.py
+++ b/healpix_alchemy/__init__.py
@@ -1,3 +1,3 @@
-from .point import Point, HasPoint
+from .point import Point
 
-__all__ = ('Point', 'HasPoint')
+__all__ = ('Point',)

--- a/healpix_alchemy/point.py
+++ b/healpix_alchemy/point.py
@@ -1,22 +1,27 @@
 """Spatial indexing for astronomical point coordinates."""
 from sqlalchemy.ext.declarative import declared_attr
-from sqlalchemy.ext.hybrid import Comparator, hybrid_property
+from sqlalchemy.ext.hybrid import hybrid_method, hybrid_property
 from sqlalchemy.schema import Column, Index
 from sqlalchemy.sql import and_
 from sqlalchemy.types import Float
 
 from .math import sind, cosd
 
-__all__ = ('Point', 'HasPoint', 'HasNullablePoint')
+__all__ = ('Point',)
 
 
-class Point(Comparator):
+class Point:
+    """Mixin class to add a point to a an SQLAlchemy declarative model."""
 
-    def __init__(self, ra, dec):
-        self._ra = ra
-        self._dec = dec
+    def __init__(self, *args, ra=None, dec=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.ra = ra
+        self.dec = dec
 
-    @property
+    ra = Column(Float)
+    dec = Column(Float)
+
+    @hybrid_property
     def cartesian(self):
         """Convert to Cartesian coordinates.
 
@@ -26,10 +31,11 @@ class Point(Comparator):
             A tuple of the x, y, and z coordinates.
 
         """
-        return (cosd(self._ra) * cosd(self._dec),
-                sind(self._ra) * cosd(self._dec),
-                sind(self._dec))
+        return (cosd(self.ra) * cosd(self.dec),
+                sind(self.ra) * cosd(self.dec),
+                sind(self.dec))
 
+    @hybrid_method
     def within(self, other, radius):
         """Test if this point is within a given radius of another point.
 
@@ -53,36 +59,11 @@ class Point(Comparator):
         bounding_box_terms, dot_product_terms = zip(*terms)
         return and_(*bounding_box_terms, sum(dot_product_terms) >= cos_radius)
 
-
-def point_factory(nullable=False):
-
-    class _HasPoint:
-        """Mixin class to add a point to a an SQLAlchemy declarative model."""
-
-        ra = Column(Float, nullable=nullable)
-        dec = Column(Float, nullable=nullable)
-
-        @hybrid_property
-        def point(self):
-            return Point(self.ra, self.dec)
-
-        @point.setter
-        def point(self, value):
-            self.ra = value._ra
-            self.dec = value._dec
-
-        @declared_attr
-        def __table_args__(cls):
-            try:
-                args = super().__table_args__
-            except AttributeError:
-                args = ()
-            index_name = f'ix_{cls.__tablename__}_point'
-            args += (Index(index_name, *cls.point.cartesian),)
-            return args
-
-    return _HasPoint
-
-
-HasPoint = point_factory()
-HasNullablePoint = point_factory(nullable=True)
+    @declared_attr
+    def __table_args__(cls):
+        try:
+            args = super().__table_args__
+        except AttributeError:
+            args = ()
+        args += (Index(f'ix_{cls.__tablename__}_point', *cls.cartesian),)
+        return args


### PR DESCRIPTION
This way, the same Point class may be used to express both a model mixin class or a point literal.

This approach will be more easily generalized to other geometric primitives (regions, rasters) and involves less SQLAlchemy magic.