### PR TITLE
Follow API change in mocpy 0.9.0

### DIFF
--- a/healpix_alchemy/healpix.py
+++ b/healpix_alchemy/healpix.py
@@ -2,14 +2,14 @@
 from astropy.coordinates import ICRS
 from astropy import units as u
 from astropy_healpix import level_to_nside, uniq_to_level_ipix, HEALPix
-from mocpy import MOC
+from mocpy import MOC, IntervalSet
 import numpy as np
 from sqlalchemy import BigInteger, Column
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm import relationship
 from sqlalchemy.orm.mapper import Mapper
 
-LEVEL = MOC.HPY_MAX_NORDER
+LEVEL = IntervalSet.HPX_MAX_ORDER
 """Base HEALPix resolution. This is the maximum HEALPix level that can be
 stored in a signed 8-byte integer data type."""
 

--- a/healpix_alchemy/tests/test_regions.py
+++ b/healpix_alchemy/tests/test_regions.py
@@ -5,7 +5,7 @@ from astropy.table import Table
 from astropy import units as u
 from astropy.utils.data import get_readable_fileobj
 from astropy_healpix import level_ipix_to_uniq
-from mocpy import MOC
+from mocpy import MOC, IntervalSet
 import numpy as np
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import Column, Integer, ForeignKey
@@ -108,7 +108,7 @@ def test_tile(engine):
     """Generate an example Tile and confirm index calculation."""
     Base.metadata.create_all(engine)
 
-    LEVEL = MOC.HPY_MAX_NORDER
+    LEVEL = IntervalSet.HPX_MAX_ORDER
 
     level, ipix = 3, 12
     value = level_ipix_to_uniq(level, ipix)

--- a/poetry.lock
+++ b/poetry.lock
@@ -462,7 +462,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "0df64659716b465b543e8d0981dc71ced483fd5b40244080a240440d84ed401d"
+content-hash = "116e760760ff68020e4b9c151a25f25631f0e535734d0069a349a63cc2009bef"
 
 [metadata.files]
 astropy = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 python = "^3.6"
 astropy = "*"
 astropy_healpix = "*"
-mocpy = "*"
+mocpy = ">=0.9"
 sqlalchemy = "*"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
The constant `mocpy.MOC.HPY_MAX_NORDER` was removed. The constant is still available as `mocpy.IntervalSet.HPX_MAX_ORDER`.