### PR TITLE
Explain area of get_ztf_footprint_corners() polygon

### DIFF
--- a/healpix_alchemy/tests/benchmarks/data.py
+++ b/healpix_alchemy/tests/benchmarks/data.py
@@ -25,7 +25,17 @@ from .models import Galaxy, Field, FieldTile, Skymap, SkymapTile
 
 
 def get_ztf_footprint_corners():
-    """Return the corner offsets of the ZTF footprint."""
+    """Return the corner offsets of the ZTF footprint.
+
+    Notes
+    -----
+    This polygon is smaller than the spatial extent of the true ZTF field of
+    view, but has approximately the same area because the real ZTF field of
+    view has chip gaps.
+
+    For the real ZTF footprint, use the region file
+    https://github.com/skyportal/skyportal/blob/main/data/ZTF_Region.reg.
+    """
     x = 6.86 / 2
     return [-x, +x, +x, -x] * u.deg, [-x, -x, +x, +x] * u.deg
 


### PR DESCRIPTION
Add a docstring to explain that this polygon is smaller than the spatial extent of the true ZTF field of view, but has approximately the same area because the real ZTF field of view has chip gaps.

I had painstakingly worked out this polygon by solving for the geometry to get an area of about 47 deg2 but I forgot to document what I did!

For the real ZTF footprint, use the region file
https://github.com/skyportal/skyportal/blob/main/data/ZTF_Region.reg.