### PR TITLE
Run benchmarks on newest, not oldest, version of Python

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -28,7 +28,7 @@ jobs:
         include:
           # only run benchmarks for the following configuration...
           - os: ubuntu-latest
-            python-version: 3.9
+            python-version: 3.12
             benchmark: true
 
     steps:


### PR DESCRIPTION
Python has been getting faster with each minor version. This may result in slightly faster CI pipelines.