### PR TITLE
Install PostgreSQL for macOS CI jobs

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -38,6 +38,9 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Install PostgreSQL
+      if: ${{ runner.os == 'macOS' }}
+      run: brew install postgresql
     - name: Set up Poetry
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
GitHub's Actions runners for macOS stopped bundling PostgreSQL, so now we have to install it manually.