### PR TITLE
Coerce mocpy's LEVEL to a Python int

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@
   be supported by scientific Python packages as per SPEC-0. Run unit tests for
   Python 3.11 through 3.14.
 
+- Coerce ``LEVEL`` to a Python ``int``. Newer versions of mocpy return
+  ``MOC.MAX_ORDER`` as a ``numpy.uint8``, which silently overflowed in
+  expressions such as ``4**LEVEL``.
+
 ## 1.1.0 (2024-04-16)
 
 - Don't include the unit tests in the installed Python package.

--- a/healpix_alchemy/constants.py
+++ b/healpix_alchemy/constants.py
@@ -4,9 +4,13 @@ from astropy.coordinates import ICRS
 from astropy_healpix import HEALPix, level_to_nside
 from mocpy import MOC
 
-LEVEL = MOC.MAX_ORDER
+LEVEL = int(MOC.MAX_ORDER)
 """Base HEALPix resolution. This is the maximum HEALPix level that can be
-stored in a signed 8-byte integer data type."""
+stored in a signed 8-byte integer data type.
+
+Coerced to a Python :class:`int` because newer versions of mocpy return
+:class:`numpy.uint8`, which would silently overflow in expressions like
+``4**LEVEL``."""
 
 HPX = HEALPix(nside=level_to_nside(LEVEL), order="nested", frame=ICRS())
 """HEALPix projection object."""

--- a/healpix_alchemy/constants.py
+++ b/healpix_alchemy/constants.py
@@ -4,13 +4,11 @@ from astropy.coordinates import ICRS
 from astropy_healpix import HEALPix, level_to_nside
 from mocpy import MOC
 
+# Coerce to a Python int because newer versions of mocpy return a numpy.uint8,
+# which would silently overflow in expressions like 4**LEVEL.
 LEVEL = int(MOC.MAX_ORDER)
 """Base HEALPix resolution. This is the maximum HEALPix level that can be
-stored in a signed 8-byte integer data type.
-
-Coerced to a Python :class:`int` because newer versions of mocpy return
-:class:`numpy.uint8`, which would silently overflow in expressions like
-``4**LEVEL``."""
+stored in a signed 8-byte integer data type."""
 
 HPX = HEALPix(nside=level_to_nside(LEVEL), order="nested", frame=ICRS())
 """HEALPix projection object."""


### PR DESCRIPTION
This PR coerces mocpy's ``LEVEL`` to a Python ``int``.